### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4235,7 +4235,7 @@ ${css}
 
       if (this.hasAttribute("block")) {
         // normalize the tab indents
-        content = content.replace(/\n/, "");
+        content = content.replace(/\n/g, "");
         const tabs = content.match(/\s*/);
         content = content.replace(new RegExp("\n" + tabs, "g"), "\n");
         content = content.trim();


### PR DESCRIPTION
Potential fix for [https://github.com/stevebaeyen/stevebaeyen.github.io/security/code-scanning/1](https://github.com/stevebaeyen/stevebaeyen.github.io/security/code-scanning/1)

To fix the problem, we should ensure that all newline characters are removed from the `content` string, not just the first one. This can be achieved by adding the global `g` flag to the regular expression in the `replace` call. Specifically, change `content.replace(/\n/, "")` to `content.replace(/\n/g, "")` on line 4238. No additional imports or methods are required, as this is standard JavaScript functionality. Only the affected line in the file `assets/js/distillpub/template.v2.js` needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
